### PR TITLE
Add custom base url option with examples

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -29,15 +29,16 @@
     <a data-module="SocialShareButton"
        data-module-text="This is a custom text"
        data-module-title="This is a custom title"
-       data-module-net="linkedin">Share on LinkedIn custom</a>
+       data-module-base-url="http://firstandthird.com/"
+       data-module-net="linkedin">Share on LinkedIn custom all</a>
   </li>
-
   <li>
     <a data-module="SocialShareButton"
        data-module-text="No water in mars yet"
        data-module-tags="not,awesome"
        data-module-via="NASA"
-       data-module-net="twitter">Share on Twitter all custom</a>
+       data-module-base-url="http://firstandthird.com/"
+       data-module-net="twitter">Share on Twitter custom all</a>
   </li>
   <li>
     <a data-module="SocialShareButton"
@@ -52,6 +53,7 @@
     <a data-module="SocialShareButton"
        data-module-net="email"
        data-module-subject="My custom Subject"
+       data-module-base-url="http://firstandthird.com/"
        data-module-body="Custom body on #url and repeating #url">Share on Email custom all</a>
   </li>
   <li>
@@ -67,6 +69,33 @@
        data-module-tag="AwesomeTag"
        data-module-text="This is my text AKA caption"
        data-module-net="facebook">Share on Facebook with text and hashtag</a>
+  </li>
+  <li>
+    <a data-module="SocialShareButton"
+       data-module-base-url="http://firstandthird.com/"
+       data-module-text="This is a custom text"
+       data-module-title="This is a custom title"
+       data-module-net="facebook">Share on Facebook custom url</a>
+  </li>
+  <li>
+    <a data-module="SocialShareButton"
+       data-module-base-url="http://firstandthird.com/"
+       data-module-text="This is a custom text"
+       data-module-title="This is a custom title"
+       data-module-net="linkedin">Share on LinkedIn custom url</a>
+  </li>
+  <li>
+    <a data-module="SocialShareButton"
+       data-module-base-url="http://firstandthird.com/"
+       data-module-net="email"
+       data-module-subject="My custom Subject">Share on Email custom url</a>
+  </li>
+  <li>
+    <a data-module="SocialShareButton"
+       data-module-base-url="http://firstandthird.com/"
+       data-module-tag="AwesomeTag"
+       data-module-text="This is my text AKA caption"
+       data-module-net="twitter">Share on Twitter custom url</a>
   </li>
 </ul>
 <script src="../dist/social-share-button.js"></script>

--- a/lib/social-share-button.js
+++ b/lib/social-share-button.js
@@ -37,6 +37,10 @@ export default class SocialShareButton extends Domodule {
     };
   }
 
+  getShareUrl() {
+    return this.options.baseUrl || window.location.href;
+  }
+
   gplusShare() {
     SocialShareButton.openWindow(this.el.href, '600', '500', 'gplusWindow');
   }
@@ -72,7 +76,7 @@ export default class SocialShareButton extends Domodule {
   }
 
   facebookSetup() {
-    const params = [`u=${window.location.href}`];
+    const params = [`u=${this.getShareUrl()}`];
 
     if (this.options.tag) {
       params.push(`hashtag=${encodeURIComponent(`#${this.options.tag}`)}`);
@@ -88,19 +92,19 @@ export default class SocialShareButton extends Domodule {
   emailSetup() {
     const title = encodeURIComponent(this.options.subject || document.title);
     let body = this.options.body || 'Check this out #url';
-    body = body.replace(/#url/gi, window.location.href);
+    body = body.replace(/#url/gi, this.getShareUrl());
     body = encodeURIComponent(body);
 
     this.el.href = `mailto:?subject=${title}&body=${body}`;
   }
 
   gplusSetup() {
-    this.el.href = `${BASE_URLS.gplus}?url=${window.location.href}`;
+    this.el.href = `${BASE_URLS.gplus}?url=${this.getShareUrl()}`;
   }
 
   linkedinSetup() {
     const params = [
-      `url=${encodeURIComponent(window.location.href)}`
+      `url=${encodeURIComponent(this.getShareUrl())}`
     ];
 
     const shareText = this.options.text;
@@ -118,13 +122,12 @@ export default class SocialShareButton extends Domodule {
   }
 
   twitterSetup() {
-    const shareUrl = window.location.href;
     const shareText = this.options.text || SocialShareButton.getTwiMeta('text');
     const shareTag = this.options.tags || SocialShareButton.getTwiMeta('hashtag');
     const shareVia = this.options.via || SocialShareButton.getTwiMeta('author');
     const params = [];
 
-    params.push(`url=${encodeURIComponent(shareUrl)}`);
+    params.push(`url=${encodeURIComponent(this.getShareUrl())}`);
 
     if (shareText) {
       params.push(`text=${encodeURIComponent(shareText)}`);


### PR DESCRIPTION
- New option: data-module-base-url
- Rationale: Library currently only pulls in the url from window.location.href; it does not yet allow users to share external links on social media
- Example of use case: On landing pages, the share button should allow user to share an external link (currently, it would only allow the user to share the landing page itself)